### PR TITLE
Update Nissan Frontier generations: correct D22 start year from 1998 to 1997

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# Model make
+# Nissan Frontier
 
+This repository contains signal set configurations for the Nissan Frontier, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Nissan Frontier.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,6 +1,10 @@
+references:
+  - "https://en.wikipedia.org/wiki/Nissan_Frontier_(North_America)"
+  - "https://en.wikipedia.org/wiki/Nissan_Navara"
+
 generations:
   - name: "First Generation (D22)"
-    start_year: 1998
+    start_year: 1997
     end_year: 2004
     description: "The original Nissan Frontier (replacing the Nissan Hardbody in North America) was introduced as a compact pickup truck available in Regular and King Cab configurations, with a Crew Cab variant added in 2000. Power initially came from a 2.4L four-cylinder engine producing 143 horsepower, with a 3.3L V6 option generating 170 horsepower added in 1999. Transmission choices included 5-speed manual and 4-speed automatic, with both rear-wheel and four-wheel drive available. The design featured rugged, angular styling with flared fenders resembling those of the larger Titan pickup. Notable variants included the Desert Runner offering the look and raised suspension of the 4x4 with rear-wheel drive, and the supercharged SC model introduced in 2001 boosting V6 output to 210 horsepower. The interior was basic but functional, focusing on durability rather than luxury, though higher trims offered amenities including air conditioning, power accessories, and upgraded audio systems. The first generation established the Frontier's reputation for durability and off-road capability at a value price point, competing primarily with the Toyota Tacoma and Ford Ranger in the compact truck segment."
 


### PR DESCRIPTION
- D22 generation now correctly shows 1997-2004 (Wikipedia confirms US introduction in 1997)
- Added proper references array with Wikipedia article links
- Updated README.md with proper template documentation

References:
- https://en.wikipedia.org/wiki/Nissan_Frontier_(North_America)
- https://en.wikipedia.org/wiki/Nissan_Navara

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
